### PR TITLE
First set of updates to generalise notebook contents

### DIFF
--- a/easi_tools/deployments.py
+++ b/easi_tools/deployments.py
@@ -10,23 +10,22 @@ import collections
 # Map an internal deployment name to deployment variables and search parameters.
 # Update to ensure that the product/space/time parameters are available in the respective databases
 deployment_map = {
-    'csiro': {
-        'domain': 'csiro.easi-eo.solutions',
-        'db_database': 'easihub_csiro_db',
+    'adias': {
+        'domain': 'adias.aquawatchaus.space',
+        'db_database': '',
         'training_shapefile': '',
-        'scratch': 'easihub-csiro-user-scratch',
-        'productmap': {'landsat': 'ga_ls8c_ard_3', 'sentinel-2': 'ga_s2am_ard_3', 'dem': 'copernicus_dem_30'},
-        'location': 'Lake Hume, Australia',
-        'latitude': (-36.3, -35.8),
-        'longitude': (146.8, 147.3),
-        'time': ('2020-02-01', '2020-04-01'),
+        'scratch': '',
+        'productmap': {'landsat': 'landsat8_c2l2_sr', 'sentinel-2': 's2_l2a', 'sar': 'asf_s1_grd_gamma0', 'dem': 'copernicus_dem_30'},
+        'location': '',
+        'latitude': (0, 0),
+        'longitude': (0, 0),
+        'time': ('', ''),
         'aliases': {
-            'landsat': {'red': 'nbart_red', 'green': 'nbart_green', 'blue': 'nbart_blue',
-                        'nir': 'nbart_nir', 'swir1': 'nbart_swir_1', 'swir2': 'nbart_swir_2',
-                        'qa_band': 'oa_fmask'}
+            'landsat': {'qa_band': 'qa_pixel', 'nir': 'nir08', 'swir1': 'swir16', 'swir2': 'swir22'}
         },
         'qa_mask': {
-            'landsat': {'fmask':'valid'}
+            'landsat': {'nodata': False, 'water': 'land_or_cloud',
+                        'cloud': 'not_high_confidence', 'cloud_shadow': 'not_high_confidence'}
         }
     },
     'asia': {
@@ -45,7 +44,7 @@ deployment_map = {
             'sentinel-2': {'crs': 'epsg:32650', 'resolution': (-10,10)}
         },
         'aliases': {
-            'landsat': {'qa_band': 'qa_pixel'}
+            'landsat': {'qa_band': 'qa_pixel', 'nir': 'nir08', 'swir1': 'swir16', 'swir2': 'swir22'}
         },
         'qa_mask': {
             'landsat': {'nodata': False, 'water': 'land_or_cloud',
@@ -69,25 +68,7 @@ deployment_map = {
             'sentinel-2': {'crs': 'epsg:32718', 'resolution': (-10,10)}
         },
         'aliases': {
-            'landsat': {'qa_band': 'qa_pixel'},
-        },
-        'qa_mask': {
-            'landsat': {'nodata': False, 'water': 'land_or_cloud',
-                        'cloud': 'not_high_confidence', 'cloud_shadow': 'not_high_confidence'}
-        }
-    },
-    'adias': {
-        'domain': 'adias.aquawatchaus.space',
-        'db_database': '',
-        'training_shapefile': '',
-        'scratch': '',
-        'productmap': {'landsat': 'landsat8_c2l2_sr', 'sentinel-2': 's2_l2a', 'sar': 'asf_s1_grd_gamma0', 'dem': 'copernicus_dem_30'},
-        'location': '',
-        'latitude': (0, 0),
-        'longitude': (0, 0),
-        'time': ('', ''),
-        'aliases': {
-            'landsat': {'qa_band': 'qa_pixel'},
+            'landsat': {'qa_band': 'qa_pixel', 'nir': 'nir08', 'swir1': 'swir16', 'swir2': 'swir22'}
         },
         'qa_mask': {
             'landsat': {'nodata': False, 'water': 'land_or_cloud',
@@ -111,11 +92,30 @@ deployment_map = {
             'sentinel-2': {'crs': 'epsg:32618', 'resolution': (-10,10)}
         },
         'aliases': {
-            'landsat': {'qa_band': 'qa_pixel'},
+            'landsat': {'qa_band': 'qa_pixel', 'nir': 'nir08', 'swir1': 'swir16', 'swir2': 'swir22'}
         },
         'qa_mask': {
             'landsat': {'nodata': False, 'water': 'land_or_cloud',
                         'cloud': 'not_high_confidence', 'cloud_shadow': 'not_high_confidence'}
+        }
+    },
+    'csiro': {
+        'domain': 'csiro.easi-eo.solutions',
+        'db_database': 'easihub_csiro_db',
+        'training_shapefile': '',
+        'scratch': 'easihub-csiro-user-scratch',
+        'productmap': {'landsat': 'ga_ls8c_ard_3', 'sentinel-2': 'ga_s2am_ard_3', 'dem': 'copernicus_dem_30'},
+        'location': 'Lake Hume, Australia',
+        'latitude': (-36.3, -35.8),
+        'longitude': (146.8, 147.3),
+        'time': ('2020-02-01', '2020-04-01'),
+        'aliases': {
+            'landsat': {'red': 'nbart_red', 'green': 'nbart_green', 'blue': 'nbart_blue',
+                        'nir': 'nbart_nir', 'swir1': 'nbart_swir_1', 'swir2': 'nbart_swir_2',
+                        'qa_band': 'oa_fmask'}
+        },
+        'qa_mask': {
+            'landsat': {'fmask':'valid'}
         }
     },
     'sub-apse2': {
@@ -130,6 +130,14 @@ deployment_map = {
         'latitude': (-36.3, -35.8),
         'longitude': (146.8, 147.3),
         'time': ('2020-02-01', '2020-04-01'),
+        'aliases': {
+            'landsat': {'red': 'nbart_red', 'green': 'nbart_green', 'blue': 'nbart_blue',
+                        'nir': 'nbart_nir', 'swir1': 'nbart_swir_1', 'swir2': 'nbart_swir_2',
+                        'qa_band': 'oa_fmask'}
+        },
+        'qa_mask': {
+            'landsat': {'fmask':'valid'}
+        }
     },
 }
 


### PR DESCRIPTION
This PR brings in the first in a group of changes intended to make the tutorial notebooks more generalised across different EASI implementations.

__NOTE:__ This has already had the latest changes from #7 and #8 merged prior to submitting this PR.

There are numerous changes, but key updates include:
- change `EasiNotebooks()` to `EasiDefaults()` and use `easi` instead of `this` as the instantiation of `EasiDefaults()`
- ability to auto-discover the EASI implementation based on `db_database` environment variable (this could/should be replaced with a dedicated env var to name the installation)
- extension of functionality in deployments.py for additional functionality
- Notebook changes to reflect changes to `EasiDefaults()`
- Notebook changes to make the language more general (e.g. removal of specific mentions of details related to specific regions, locations or installations)
- Simplification and "de-Australianisation" of some language
- Various updates to explanations, new images and diagrams added to some notebooks

Issues and To Do:
- __ISSUE:__ how should we handle differences in measurement names? In the international EASI implementations, we don't have the Australian products (e.g. ga_ls8c_ard_3), which has different measurement names (nbart_*, fmask, etc). For the tutorial notebooks, we probably have three options:
    1. use common products (probably not practical given that EASI Australia doesn't have the same Landsat and Sentinel-2 products as the others)
    2. be explicit about requesting measurements in the notebook code, although ga_ls8c_ard_3 and landsat8_c2l2_sr for example will need common aliases, which is not currently the case. This would require some updates to product definitions.
    3. extend deployments.py to add measurement mapping as part of the product mapping. This is achievable but adds makes deployments.py more complex.
- __TODO:__ Still need to update the remaining Dask tutorials (in particular "Go big or go home" 1 and 2) to deal with the changes in Dask from reporting "Tasks" to "graph layers"
- __TODO:__ We need to discuss and decide which notebooks to bring across from hub-notebooks (most of which have now been updated fully to use `EasiDefaults()` and tested in both EAIL and Chile)